### PR TITLE
Add initial pinned requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+Flask==2.3.3
+Celery==5.3.4
+redis==5.0.1
+google-api-python-client==2.95.0
+google-auth-oauthlib==1.1.0
+google-auth-httplib2==0.2.0
+python-dotenv==1.0.1
+# Front-end libraries (served via Flask static files)
+jquery==3.7.1
+bootstrap==5.3.2


### PR DESCRIPTION
## Summary
- add requirements.txt with pinned versions for Flask, Celery, Redis, Google API libs, python-dotenv, and front-end libraries

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ead1e120083279544e6f92ffc8de4