### PR TITLE
Implement Celery scheduler task

### DIFF
--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from celery import Celery
+
+from config import Config
+
+celery_app = Celery(
+    "codex_uploader",
+    broker=Config.REDIS_URL,
+    backend=Config.REDIS_URL,
+)
+
+# Automatically discover tasks from the "tasks" package
+celery_app.autodiscover_tasks(["tasks"])
+

--- a/tasks/scheduler.py
+++ b/tasks/scheduler.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.celery_app import celery_app
+from app import models
+
+
+@celery_app.task(name="tasks.scheduler.enqueue_uploads")
+def enqueue_uploads(project_id: int) -> int:
+    """Enqueue upload tasks for the given project based on its schedule."""
+    schedules = models.get_schedules(project_id)
+    count = 0
+    for item in schedules:
+        eta = datetime.fromisoformat(item["scheduled_at"])
+        celery_app.send_task(
+            "tasks.youtube.upload_video",
+            args=[project_id, item["id"], item.get("metadata")],
+            eta=eta,
+        )
+        count += 1
+    return count
+


### PR DESCRIPTION
## Summary
- add Celery application setup
- create scheduler task to enqueue uploads based on project schedules
- make tasks package importable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f06c48744832781776113355d5cf1