### PR TITLE
Configure Celery for RabbitMQ

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,6 +20,9 @@ def create_app(config_class: type[Config] = Config) -> Flask:
 
     app = Flask(__name__, static_folder=static_folder, template_folder=template_folder)
     app.config.from_object(config_class)
+    # Expose Celery settings for extensions that rely on Flask config
+    app.config.setdefault("CELERY_BROKER_URL", config_class.BROKER_URL)
+    app.config.setdefault("CELERY_RESULT_BACKEND", config_class.BROKER_URL)
 
     _register_blueprints(app)
     return app

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -6,8 +6,8 @@ from config import Config
 
 celery_app = Celery(
     "codex_uploader",
-    broker=Config.REDIS_URL,
-    backend=Config.REDIS_URL,
+    broker=Config.BROKER_URL,
+    backend=Config.BROKER_URL,
 )
 
 # Automatically discover tasks from the "tasks" package

--- a/config.py
+++ b/config.py
@@ -22,6 +22,8 @@ class Config:
 
     # BROKER connection string
     BROKER_URL = os.getenv("BROKER_URL", "amqp://guest:guest@localhost:5672//")
+    CELERY_BROKER_URL: str = BROKER_URL
+    CELERY_RESULT_BACKEND: str = BROKER_URL
 
     # Default upload schedule as a list of HH:MM strings
     DEFAULT_UPLOAD_TIMES: List[str] = os.getenv(


### PR DESCRIPTION
## Summary
- update config for RabbitMQ URL and Celery settings
- expose `CELERY_BROKER_URL`/`CELERY_RESULT_BACKEND` in Flask app factory
- bootstrap Celery using `BROKER_URL`

## Testing
- `pytest -q`
- `celery -A app.celery_app worker --pool=solo -l info` *(fails: command not found)*
- `python -m flask --app app run` *(fails: No module named flask)*

------
https://chatgpt.com/codex/tasks/task_e_685f0ee62bb8832784d5af544d74ecd1