### PR TITLE
Configure Celery RPC backend

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,7 +22,7 @@ def create_app(config_class: type[Config] = Config) -> Flask:
     app.config.from_object(config_class)
     # Expose Celery settings for extensions that rely on Flask config
     app.config.setdefault("CELERY_BROKER_URL", config_class.BROKER_URL)
-    app.config.setdefault("CELERY_RESULT_BACKEND", config_class.BROKER_URL)
+    app.config.setdefault("CELERY_RESULT_BACKEND", config_class.CELERY_RESULT_BACKEND)
 
     _register_blueprints(app)
     return app

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -7,7 +7,7 @@ from config import Config
 celery_app = Celery(
     "codex_uploader",
     broker=Config.BROKER_URL,
-    backend=Config.BROKER_URL,
+    backend=Config.CELERY_RESULT_BACKEND,
 )
 
 # Automatically discover tasks from the "tasks" package

--- a/config.py
+++ b/config.py
@@ -13,6 +13,9 @@ def _str_to_bool(value: Optional[str], default: bool = False) -> bool:
     return value.lower() in {"1", "true", "yes", "y", "on"}
 
 
+CELERY_RESULT_BACKEND = "rpc://"
+
+
 class Config:
     """Application configuration loaded from environment variables."""
 
@@ -23,7 +26,7 @@ class Config:
     # BROKER connection string
     BROKER_URL = os.getenv("BROKER_URL", "amqp://guest:guest@localhost:5672//")
     CELERY_BROKER_URL: str = BROKER_URL
-    CELERY_RESULT_BACKEND: str = BROKER_URL
+    CELERY_RESULT_BACKEND: str = CELERY_RESULT_BACKEND
 
     # Default upload schedule as a list of HH:MM strings
     DEFAULT_UPLOAD_TIMES: List[str] = os.getenv(


### PR DESCRIPTION
## Summary
- set default Celery result backend to RPC
- expose CELERY_RESULT_BACKEND in Flask app config
- use CELERY_RESULT_BACKEND when creating the Celery app

## Testing
- `pytest -q`
- `source ../venv/Scripts/activate` *(fails: No such file or directory)*
- `pip install -r ../requirements.txt` *(fails: Could not open requirements file)*
- `python -m celery -A app.celery_app worker -l info` *(fails: No module named celery)*
- `python -m flask --app app run` *(fails: No module named flask)*

------
https://chatgpt.com/codex/tasks/task_e_685f21b4c5348327b60869f9f4e15449