### PR TITLE
Handle optional python-dotenv import

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 import os
 from typing import List, Optional
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    def load_dotenv(*_args, **_kwargs) -> bool:
+        """Fallback no-op if python-dotenv is not installed."""
+        return False
 
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- allow `config.py` to load even when `python-dotenv` isn't installed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f2ded04308327a5337ee23cc86ef7