### PR TITLE
Add index blueprint and template

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,7 +50,8 @@ def _register_blueprints(app: Flask) -> None:
                 mod = importlib.import_module(f"app.views.{name}")
             except ImportError:
                 continue
-            for attr in ("bp", "blueprint", f"{name}_bp"):
+            # Also look for a module-specific blueprint name like ``index_bp``
+            for attr in ("bp", "blueprint", f"{name}_bp", "index_bp"):
                 blueprint = getattr(mod, attr, None)
                 if isinstance(blueprint, Blueprint):
                     app.register_blueprint(blueprint)

--- a/app/auth.py
+++ b/app/auth.py
@@ -109,7 +109,7 @@ def oauth2_callback() -> redirect:
     flow.fetch_token(authorization_response=request.url)
     creds = flow.credentials
     _store_credentials(creds)
-    return redirect(url_for("index"))
+    return redirect(url_for("index.index"))
 
 
 def get_credentials() -> Optional[Credentials]:

--- a/app/views/index.py
+++ b/app/views/index.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from flask import Blueprint, render_template
+
+index_bp = Blueprint("index", __name__)
+
+@index_bp.route("/")
+def index():
+    """Render the application home page."""
+    return render_template("index.html")

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Home</title>
+</head>
+<body>
+    <h1>Home</h1>
+    <ul>
+        <li><a href="/projects">Projects</a></li>
+        <li><a href="/scheduler">Scheduler</a></li>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `index` blueprint and HTML template with links to Projects and Scheduler
- update auth redirect to home page
- tweak blueprint discovery to search for `index_bp`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f337ef49883279279361b2d8e5c92