### PR TITLE
Add dashboard status bar widget

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -154,3 +154,36 @@ def update_schedule_status(schedule_id: int, status: str) -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+def get_all_statuses() -> List[Dict[str, Any]]:
+    """Return status information for all schedules."""
+    init_db()
+    conn = _get_conn()
+    try:
+        cur = conn.execute(
+            "SELECT id, project_id, scheduled_at, metadata FROM schedules"
+        )
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    results: List[Dict[str, Any]] = []
+    for row in rows:
+        meta = {}
+        if row["metadata"]:
+            try:
+                meta = json.loads(row["metadata"])
+            except json.JSONDecodeError:
+                meta = {}
+        status = meta.get("status", "queued")
+        results.append(
+            {
+                "id": row["id"],
+                "project_id": row["project_id"],
+                "scheduled_at": row["scheduled_at"],
+                "status": status,
+            }
+        )
+
+    return results

--- a/app/views/dashboard.py
+++ b/app/views/dashboard.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, render_template
+
+from .. import models
+
+
+dashboard_bp = Blueprint("dashboard", __name__)
+
+
+@dashboard_bp.route("/dashboard")
+def dashboard_page():
+    """Render dashboard with status bars."""
+    return render_template("dashboard.html")
+
+
+@dashboard_bp.route("/api/status")
+def status_api():
+    """Return JSON status for all scheduled uploads."""
+    statuses = models.get_all_statuses()
+    return jsonify(statuses)

--- a/static/js/status_bar.js
+++ b/static/js/status_bar.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('status-container');
+
+    function statusToPercent(status) {
+        switch (status) {
+            case 'uploading':
+                return 50;
+            case 'uploaded':
+            case 'done':
+                return 100;
+            case 'failed':
+                return 100;
+            default:
+                return 0;
+        }
+    }
+
+    function renderStatus(data) {
+        container.innerHTML = '';
+        data.forEach(item => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'status-item';
+
+            const label = document.createElement('div');
+            label.textContent = `Video ${item.id}`;
+            wrapper.appendChild(label);
+
+            const bar = document.createElement('div');
+            bar.className = 'status-bar';
+            if (item.status === 'failed') {
+                bar.classList.add('failed');
+            }
+
+            const progress = document.createElement('div');
+            progress.className = 'progress';
+            progress.style.width = statusToPercent(item.status) + '%';
+            progress.textContent = item.status;
+            bar.appendChild(progress);
+            wrapper.appendChild(bar);
+
+            container.appendChild(wrapper);
+        });
+    }
+
+    function fetchStatus() {
+        fetch('/api/status')
+            .then(resp => resp.json())
+            .then(renderStatus)
+            .catch(err => console.error('Failed to load status', err));
+    }
+
+    fetchStatus();
+    setInterval(fetchStatus, 5000);
+});

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Upload Dashboard</title>
+    <style>
+        .status-item { margin-bottom: 1em; }
+        .status-bar { border: 1px solid #ccc; width: 300px; height: 20px; position: relative; }
+        .status-bar .progress { background: #4caf50; height: 100%; width: 0; color: #fff; text-align: center; line-height: 20px; transition: width 0.5s; }
+        .status-bar.failed .progress { background: #d9534f; }
+    </style>
+    <script src="{{ url_for('static', filename='js/status_bar.js') }}" defer></script>
+</head>
+<body>
+    <h1>Upload Status</h1>
+    <div id="status-container"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- display upload dashboard page
- poll `/api/status` for updates and show progress bars
- expose dashboard and API endpoints
- add helper to fetch schedule statuses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fadbd8a9483279de80bef5d0f9a5d